### PR TITLE
Add support for MS IE and MS Edge

### DIFF
--- a/src/api/selection.js
+++ b/src/api/selection.js
@@ -52,6 +52,36 @@ define(function () {
       }
     }
 
+    // With MS Edge, ranges that will be converted to selection require
+    // to start or end on a text node otherwise when normalizing the text nodes
+    // in the selection it won't be correct.
+
+    function setRangeStart(range, marker) {
+      var prevSibling = marker.previousSibling;
+      var nextSibling = marker.nextSibling;
+
+      if (prevSibling && prevSibling.nodeType === Node.TEXT_NODE) {
+        range.setStart(prevSibling, prevSibling.data.length);
+      } else if (nextSibling && nextSibling.nodeType === Node.TEXT_NODE) {
+        range.setStart(nextSibling, 0);
+      } else {
+        range.setStartBefore(marker);
+      }
+    }
+
+    function setRangeEnd(range, marker) {
+      var prevSibling = marker.previousSibling;
+      var nextSibling = marker.nextSibling;
+
+      if (prevSibling && prevSibling.nodeType === Node.TEXT_NODE) {
+        range.setEnd(prevSibling, prevSibling.data.length);
+      } else if (nextSibling && nextSibling.nodeType === Node.TEXT_NODE) {
+        range.setEnd(nextSibling, 0);
+      } else {
+        range.setEndAfter(marker);
+      }
+    }
+
     /**
      * Wrapper for object holding currently selected text.
      */
@@ -158,10 +188,10 @@ define(function () {
 
       var newRange = document.createRange();
 
-      newRange.setStartBefore(markers[0]);
+      setRangeStart(newRange, markers[0]);
       // We always reset the end marker because otherwise it will just
       // use the current range’s end marker.
-      newRange.setEndAfter(markers.length >= 2 ? markers[1] : markers[0]);
+      setRangeEnd(newRange, markers.length >= 2 ? markers[1] : markers[0]);
 
       if (! keepMarkers) {
         this.removeMarkers();

--- a/src/node.js
+++ b/src/node.js
@@ -152,6 +152,25 @@ define([
     });
   }
 
+  /**
+   * IE does not have CustomEvent constructor to directly create custom events.
+   * This is why we use the deprecated `document.createEvent` method for IE.
+   */
+
+  var createCustomEvent;
+
+  if (typeof window.CustomEvent !== 'function') {
+    createCustomEvent = function(eventType, options) {
+      var event = document.createEvent('CustomEvent');
+      event.initEvent(eventType, !!options.bubbles, !!options.cancelable, options.detail || null);
+      return event;
+    };
+  } else {
+    createCustomEvent = function(eventType, options) {
+      return new CustomEvent(eventType, options);
+    };
+  }
+
   return {
     isInlineElement: isInlineElement,
     isBlockElement: isBlockElement,
@@ -170,7 +189,8 @@ define([
     wrap: wrap,
     unwrap: unwrap,
     removeChromeArtifacts: removeChromeArtifacts,
-    elementHasClass: elementHasClass
+    elementHasClass: elementHasClass,
+    createCustomEvent: createCustomEvent
   };
 
 });

--- a/src/shims/dom_shims.js
+++ b/src/shims/dom_shims.js
@@ -1,0 +1,41 @@
+define(function() {
+  'use strict';
+
+  return function() {
+    // IE does not implement `Document.prototype.contains`
+    if (typeof Document.prototype.contains !== 'function') {
+      Object.defineProperty(Document.prototype, 'contains', {
+        writable: true,
+        enumerable: false,
+        configurable: true,
+        value: function(el) {
+          if (!el) return false;
+          return this.documentElement.contains(el);
+        }
+      });
+    }
+
+    // IE does not implement `Range.prototype.intersectsNode`
+    if (typeof Range.prototype.intersectsNode !== 'function') {
+      Object.defineProperty(Range.prototype, 'intersectsNode', {
+        writable: true,
+        enumerable: false,
+        configurable: true,
+        value: function(node) {
+          if (!node) {
+            throw new TypeError("Failed to execute 'intersectsNode' on 'Range': 1 argument required, but only 0 present.");
+          }
+          if (this.startContainer.ownerDocument !== node.ownerDocument) return false;
+          if (!node.parentNode) return true;
+
+          var targetRange = document.createRange();
+          targetRange.selectNode(node);
+          var startEnd = this.compareBoundaryPoints(Range.START_TO_END, targetRange);
+          var endStart = this.compareBoundaryPoints(Range.END_TO_START, targetRange);
+
+          return startEnd === 1 && endStart === -1;
+        }
+      });
+    }
+  };
+});

--- a/src/shims/mutation_observer.js
+++ b/src/shims/mutation_observer.js
@@ -1,0 +1,578 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+define(function() {
+  return function() {
+    var global = typeof window !== 'undefined' ? window : null;
+    if (!global) return;
+
+    // Don't allow this object to be redefined.
+    if (global.JsMutationObserver) {
+      return;
+    }
+
+    var registrationsTable = new WeakMap();
+
+    var setImmediate;
+
+    // As much as we would like to use the native implementation, IE
+    // (all versions) suffers a rather annoying bug where it will drop or defer
+    // callbacks when heavy DOM operations are being performed concurrently.
+    //
+    // For a thorough discussion on this, see:
+    // http://codeforhire.com/2013/09/21/setimmediate-and-messagechannel-broken-on-internet-explorer-10/
+    if (/Trident|Edge/.test(navigator.userAgent)) {
+      // Sadly, this bug also affects postMessage and MessageQueues.
+      //
+      // We would like to use the onreadystatechange hack for IE <= 10, but it is
+      // dangerous in the polyfilled environment due to requiring that the
+      // observed script element be in the document.
+      setImmediate = setTimeout;
+
+    // If some other browser ever implements it, let's prefer their native
+    // implementation:
+    } else if (window.setImmediate) {
+      setImmediate = window.setImmediate;
+
+    // Otherwise, we fall back to postMessage as a means of emulating the next
+    // task semantics of setImmediate.
+    } else {
+      var setImmediateQueue = [];
+      var sentinel = String(Math.random());
+      window.addEventListener('message', function(e) {
+        if (e.data === sentinel) {
+          var queue = setImmediateQueue;
+          setImmediateQueue = [];
+          queue.forEach(function(func) {
+            func();
+          });
+        }
+      });
+      setImmediate = function(func) {
+        setImmediateQueue.push(func);
+        window.postMessage(sentinel, '*');
+      };
+    }
+
+    // This is used to ensure that we never schedule 2 callas to setImmediate
+    var isScheduled = false;
+
+    // Keep track of observers that needs to be notified next time.
+    var scheduledObservers = [];
+
+    /**
+     * Schedules |dispatchCallback| to be called in the future.
+     * @param {MutationObserver} observer
+     */
+    function scheduleCallback(observer) {
+      scheduledObservers.push(observer);
+      if (!isScheduled) {
+        isScheduled = true;
+        setImmediate(dispatchCallbacks);
+      }
+    }
+
+    function wrapIfNeeded(node) {
+      return window.ShadowDOMPolyfill &&
+          window.ShadowDOMPolyfill.wrapIfNeeded(node) ||
+          node;
+    }
+
+    function dispatchCallbacks() {
+      // http://dom.spec.whatwg.org/#mutation-observers
+
+      isScheduled = false; // Used to allow a new setImmediate call above.
+
+      var observers = scheduledObservers;
+      scheduledObservers = [];
+      // Sort observers based on their creation UID (incremental).
+      observers.sort(function(o1, o2) {
+        return o1.uid_ - o2.uid_;
+      });
+
+      var anyNonEmpty = false;
+      observers.forEach(function(observer) {
+
+        // 2.1, 2.2
+        var queue = observer.takeRecords();
+        // 2.3. Remove all transient registered observers whose observer is mo.
+        removeTransientObserversFor(observer);
+
+        // 2.4
+        if (queue.length) {
+          observer.callback_(queue, observer);
+          anyNonEmpty = true;
+        }
+      });
+
+      // 3.
+      if (anyNonEmpty)
+        dispatchCallbacks();
+    }
+
+    function removeTransientObserversFor(observer) {
+      observer.nodes_.forEach(function(node) {
+        var registrations = registrationsTable.get(node);
+        if (!registrations)
+          return;
+        registrations.forEach(function(registration) {
+          if (registration.observer === observer)
+            registration.removeTransientObservers();
+        });
+      });
+    }
+
+    /**
+     * This function is used for the "For each registered observer observer (with
+     * observer's options as options) in target's list of registered observers,
+     * run these substeps:" and the "For each ancestor ancestor of target, and for
+     * each registered observer observer (with options options) in ancestor's list
+     * of registered observers, run these substeps:" part of the algorithms. The
+     * |options.subtree| is checked to ensure that the callback is called
+     * correctly.
+     *
+     * @param {Node} target
+     * @param {function(MutationObserverInit):MutationRecord} callback
+     */
+    function forEachAncestorAndObserverEnqueueRecord(target, callback) {
+      for (var node = target; node; node = node.parentNode) {
+        var registrations = registrationsTable.get(node);
+
+        if (registrations) {
+          for (var j = 0; j < registrations.length; j++) {
+            var registration = registrations[j];
+            var options = registration.options;
+
+            // Only target ignores subtree.
+            if (node !== target && !options.subtree)
+              continue;
+
+            var record = callback(options);
+            if (record)
+              registration.enqueue(record);
+          }
+        }
+      }
+    }
+
+    var uidCounter = 0;
+
+    /**
+     * The class that maps to the DOM MutationObserver interface.
+     * @param {Function} callback.
+     * @constructor
+     */
+    function JsMutationObserver(callback) {
+      this.callback_ = callback;
+      this.nodes_ = [];
+      this.records_ = [];
+      this.uid_ = ++uidCounter;
+    }
+
+    JsMutationObserver.prototype = {
+      observe: function(target, options) {
+        target = wrapIfNeeded(target);
+
+        // 1.1
+        if (!options.childList && !options.attributes && !options.characterData ||
+
+            // 1.2
+            options.attributeOldValue && !options.attributes ||
+
+            // 1.3
+            options.attributeFilter && options.attributeFilter.length &&
+                !options.attributes ||
+
+            // 1.4
+            options.characterDataOldValue && !options.characterData) {
+
+          throw new SyntaxError();
+        }
+
+        var registrations = registrationsTable.get(target);
+        if (!registrations)
+          registrationsTable.set(target, registrations = []);
+
+        // 2
+        // If target's list of registered observers already includes a registered
+        // observer associated with the context object, replace that registered
+        // observer's options with options.
+        var registration;
+        for (var i = 0; i < registrations.length; i++) {
+          if (registrations[i].observer === this) {
+            registration = registrations[i];
+            registration.removeListeners();
+            registration.options = options;
+            break;
+          }
+        }
+
+        // 3.
+        // Otherwise, add a new registered observer to target's list of registered
+        // observers with the context object as the observer and options as the
+        // options, and add target to context object's list of nodes on which it
+        // is registered.
+        if (!registration) {
+          registration = new Registration(this, target, options);
+          registrations.push(registration);
+          this.nodes_.push(target);
+        }
+
+        registration.addListeners();
+      },
+
+      disconnect: function() {
+        this.nodes_.forEach(function(node) {
+          var registrations = registrationsTable.get(node);
+          for (var i = 0; i < registrations.length; i++) {
+            var registration = registrations[i];
+            if (registration.observer === this) {
+              registration.removeListeners();
+              registrations.splice(i, 1);
+              // Each node can only have one registered observer associated with
+              // this observer.
+              break;
+            }
+          }
+        }, this);
+        this.records_ = [];
+      },
+
+      takeRecords: function() {
+        var copyOfRecords = this.records_;
+        this.records_ = [];
+        return copyOfRecords;
+      }
+    };
+
+    /**
+     * @param {string} type
+     * @param {Node} target
+     * @constructor
+     */
+    function MutationRecord(type, target) {
+      this.type = type;
+      this.target = target;
+      this.addedNodes = [];
+      this.removedNodes = [];
+      this.previousSibling = null;
+      this.nextSibling = null;
+      this.attributeName = null;
+      this.attributeNamespace = null;
+      this.oldValue = null;
+    }
+
+    function copyMutationRecord(original) {
+      var record = new MutationRecord(original.type, original.target);
+      record.addedNodes = original.addedNodes.slice();
+      record.removedNodes = original.removedNodes.slice();
+      record.previousSibling = original.previousSibling;
+      record.nextSibling = original.nextSibling;
+      record.attributeName = original.attributeName;
+      record.attributeNamespace = original.attributeNamespace;
+      record.oldValue = original.oldValue;
+      return record;
+    };
+
+    // We keep track of the two (possibly one) records used in a single mutation.
+    var currentRecord, recordWithOldValue;
+
+    /**
+     * Creates a record without |oldValue| and caches it as |currentRecord| for
+     * later use.
+     * @param {string} oldValue
+     * @return {MutationRecord}
+     */
+    function getRecord(type, target) {
+      return currentRecord = new MutationRecord(type, target);
+    }
+
+    /**
+     * Gets or creates a record with |oldValue| based in the |currentRecord|
+     * @param {string} oldValue
+     * @return {MutationRecord}
+     */
+    function getRecordWithOldValue(oldValue) {
+      if (recordWithOldValue)
+        return recordWithOldValue;
+      recordWithOldValue = copyMutationRecord(currentRecord);
+      recordWithOldValue.oldValue = oldValue;
+      return recordWithOldValue;
+    }
+
+    function clearRecords() {
+      currentRecord = recordWithOldValue = undefined;
+    }
+
+    /**
+     * @param {MutationRecord} record
+     * @return {boolean} Whether the record represents a record from the current
+     * mutation event.
+     */
+    function recordRepresentsCurrentMutation(record) {
+      return record === recordWithOldValue || record === currentRecord;
+    }
+
+    /**
+     * Selects which record, if any, to replace the last record in the queue.
+     * This returns |null| if no record should be replaced.
+     *
+     * @param {MutationRecord} lastRecord
+     * @param {MutationRecord} newRecord
+     * @param {MutationRecord}
+     */
+    function selectRecord(lastRecord, newRecord) {
+      if (lastRecord === newRecord)
+        return lastRecord;
+
+      // Check if the the record we are adding represents the same record. If
+      // so, we keep the one with the oldValue in it.
+      if (recordWithOldValue && recordRepresentsCurrentMutation(lastRecord))
+        return recordWithOldValue;
+
+      return null;
+    }
+
+    /**
+     * Class used to represent a registered observer.
+     * @param {MutationObserver} observer
+     * @param {Node} target
+     * @param {MutationObserverInit} options
+     * @constructor
+     */
+    function Registration(observer, target, options) {
+      this.observer = observer;
+      this.target = target;
+      this.options = options;
+      this.transientObservedNodes = [];
+    }
+
+    Registration.prototype = {
+      enqueue: function(record) {
+        var records = this.observer.records_;
+        var length = records.length;
+
+        // There are cases where we replace the last record with the new record.
+        // For example if the record represents the same mutation we need to use
+        // the one with the oldValue. If we get same record (this can happen as we
+        // walk up the tree) we ignore the new record.
+        if (records.length > 0) {
+          var lastRecord = records[length - 1];
+          var recordToReplaceLast = selectRecord(lastRecord, record);
+          if (recordToReplaceLast) {
+            records[length - 1] = recordToReplaceLast;
+            return;
+          }
+        } else {
+          scheduleCallback(this.observer);
+        }
+
+        records[length] = record;
+      },
+
+      addListeners: function() {
+        this.addListeners_(this.target);
+      },
+
+      addListeners_: function(node) {
+        var options = this.options;
+        if (options.attributes)
+          node.addEventListener('DOMAttrModified', this, true);
+
+        if (options.characterData)
+          node.addEventListener('DOMCharacterDataModified', this, true);
+
+        if (options.childList)
+          node.addEventListener('DOMNodeInserted', this, true);
+
+        if (options.childList || options.subtree)
+          node.addEventListener('DOMNodeRemoved', this, true);
+      },
+
+      removeListeners: function() {
+        this.removeListeners_(this.target);
+      },
+
+      removeListeners_: function(node) {
+        var options = this.options;
+        if (options.attributes)
+          node.removeEventListener('DOMAttrModified', this, true);
+
+        if (options.characterData)
+          node.removeEventListener('DOMCharacterDataModified', this, true);
+
+        if (options.childList)
+          node.removeEventListener('DOMNodeInserted', this, true);
+
+        if (options.childList || options.subtree)
+          node.removeEventListener('DOMNodeRemoved', this, true);
+      },
+
+      /**
+       * Adds a transient observer on node. The transient observer gets removed
+       * next time we deliver the change records.
+       * @param {Node} node
+       */
+      addTransientObserver: function(node) {
+        // Don't add transient observers on the target itself. We already have all
+        // the required listeners set up on the target.
+        if (node === this.target)
+          return;
+
+        this.addListeners_(node);
+        this.transientObservedNodes.push(node);
+        var registrations = registrationsTable.get(node);
+        if (!registrations)
+          registrationsTable.set(node, registrations = []);
+
+        // We know that registrations does not contain this because we already
+        // checked if node === this.target.
+        registrations.push(this);
+      },
+
+      removeTransientObservers: function() {
+        var transientObservedNodes = this.transientObservedNodes;
+        this.transientObservedNodes = [];
+
+        transientObservedNodes.forEach(function(node) {
+          // Transient observers are never added to the target.
+          this.removeListeners_(node);
+
+          var registrations = registrationsTable.get(node);
+          for (var i = 0; i < registrations.length; i++) {
+            if (registrations[i] === this) {
+              registrations.splice(i, 1);
+              // Each node can only have one registered observer associated with
+              // this observer.
+              break;
+            }
+          }
+        }, this);
+      },
+
+      handleEvent: function(e) {
+        // Stop propagation since we are managing the propagation manually.
+        // This means that other mutation events on the page will not work
+        // correctly but that is by design.
+        e.stopImmediatePropagation();
+
+        switch (e.type) {
+          case 'DOMAttrModified':
+            // http://dom.spec.whatwg.org/#concept-mo-queue-attributes
+
+            var name = e.attrName;
+            var namespace = e.relatedNode.namespaceURI;
+            var target = e.target;
+
+            // 1.
+            var record = new getRecord('attributes', target);
+            record.attributeName = name;
+            record.attributeNamespace = namespace;
+
+            // 2.
+            var oldValue =
+                e.attrChange === MutationEvent.ADDITION ? null : e.prevValue;
+
+            forEachAncestorAndObserverEnqueueRecord(target, function(options) {
+              // 3.1, 4.2
+              if (!options.attributes)
+                return;
+
+              // 3.2, 4.3
+              if (options.attributeFilter && options.attributeFilter.length &&
+                  options.attributeFilter.indexOf(name) === -1 &&
+                  options.attributeFilter.indexOf(namespace) === -1) {
+                return;
+              }
+              // 3.3, 4.4
+              if (options.attributeOldValue)
+                return getRecordWithOldValue(oldValue);
+
+              // 3.4, 4.5
+              return record;
+            });
+
+            break;
+
+          case 'DOMCharacterDataModified':
+            // http://dom.spec.whatwg.org/#concept-mo-queue-characterdata
+            var target = e.target;
+
+            // 1.
+            var record = getRecord('characterData', target);
+
+            // 2.
+            var oldValue = e.prevValue;
+
+
+            forEachAncestorAndObserverEnqueueRecord(target, function(options) {
+              // 3.1, 4.2
+              if (!options.characterData)
+                return;
+
+              // 3.2, 4.3
+              if (options.characterDataOldValue)
+                return getRecordWithOldValue(oldValue);
+
+              // 3.3, 4.4
+              return record;
+            });
+
+            break;
+
+          case 'DOMNodeRemoved':
+            this.addTransientObserver(e.target);
+            // Fall through.
+          case 'DOMNodeInserted':
+            // http://dom.spec.whatwg.org/#concept-mo-queue-childlist
+            var changedNode = e.target;
+            var addedNodes, removedNodes;
+            if (e.type === 'DOMNodeInserted') {
+              addedNodes = [changedNode];
+              removedNodes = [];
+            } else {
+
+              addedNodes = [];
+              removedNodes = [changedNode];
+            }
+            var previousSibling = changedNode.previousSibling;
+            var nextSibling = changedNode.nextSibling;
+
+            // 1.
+            var record = getRecord('childList', e.target.parentNode);
+            record.addedNodes = addedNodes;
+            record.removedNodes = removedNodes;
+            record.previousSibling = previousSibling;
+            record.nextSibling = nextSibling;
+
+            forEachAncestorAndObserverEnqueueRecord(e.relatedNode, function(options) {
+              // 2.1, 3.2
+              if (!options.childList)
+                return;
+
+              // 2.2, 3.3
+              return record;
+            });
+
+        }
+
+        clearRecords();
+      }
+    };
+
+    global.JsMutationObserver = JsMutationObserver;
+
+    if (!global.MutationObserver) {
+      global.MutationObserver = JsMutationObserver;
+      // Explicltly mark MO as polyfilled for user reference.
+      JsMutationObserver._isPolyfilled = true;
+    }
+  };
+});

--- a/src/shims/shims.js
+++ b/src/shims/shims.js
@@ -1,0 +1,11 @@
+define(['./dom_shims', './weak_map', './mutation_observer'],
+  'use strict';
+
+  function (domShims, WeakMap, MutationObserver) {
+    return function() {
+      domShims();
+      WeakMap();
+      MutationObserver();
+    };
+  }
+);

--- a/src/shims/weak_map.js
+++ b/src/shims/weak_map.js
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+define(function() {
+  'use strict';
+
+  return function() {
+    if (typeof WeakMap !== 'undefined') return;
+    if (typeof window === 'undefined') return;
+
+    var defineProperty = Object.defineProperty;
+    var counter = Date.now() % 1e9;
+
+    var WeakMap = function() {
+      this.name = '__st' + (Math.random() * 1e9 >>> 0) + (counter++ + '__');
+    };
+
+    WeakMap.prototype = {
+      constructor: WeakMap,
+      set: function(key, value) {
+        var entry = key[this.name];
+        if (entry && entry[0] === key)
+          entry[1] = value;
+        else
+          defineProperty(key, this.name, {value: [key, value], writable: true});
+        return this;
+      },
+      get: function(key) {
+        var entry;
+        return (entry = key[this.name]) && entry[0] === key ?
+            entry[1] : undefined;
+      },
+      delete: function(key) {
+        var entry = key[this.name];
+        if (!entry || entry[0] !== key) return false;
+        entry[0] = entry[1] = undefined;
+        return true;
+      },
+      has: function(key) {
+        var entry = key[this.name];
+        if (!entry) return false;
+        return entry[0] === key;
+      }
+    };
+
+    window.WeakMap = WeakMap;
+  }
+});

--- a/src/undo-manager.js
+++ b/src/undo-manager.js
@@ -1,12 +1,13 @@
 define([
-  'immutable'
-], function (Immutable) {
+  'immutable',
+  './node'
+], function (Immutable, nodeHelpers) {
   'use strict';
 
   function UndoManager(limit, undoScopeHost) {
     this._stack = Immutable.List();
     this._limit = limit;
-    this._fireEvent = typeof CustomEvent != 'undefined' && undoScopeHost && undoScopeHost.dispatchEvent;
+    this._fireEvent = undoScopeHost && undoScopeHost.dispatchEvent;
     this._ush = undoScopeHost;
 
     this.position = 0;
@@ -86,13 +87,13 @@ define([
 
   UndoManager.prototype._dispatch = function(event, transactions) {
     if (this._fireEvent) {
-      this._ush.dispatchEvent(new CustomEvent(event, {
+      this._ush.dispatchEvent(nodeHelpers.createCustomEvent(event, {
         detail: {transactions: transactions.toArray()},
         bubbles: true,
         cancelable: false
       }));
     }
-  }
+  };
 
   return UndoManager;
 });


### PR DESCRIPTION
@kencheeto @roseleaf @shajith 

This PR adds support for IE and Edge. The following features were added:
### Shims
- WeakMap (necessary for MutationObserver, borrowed from The Polymer Project)
- MutationObserver (borrowed from The Polymer Project)
- Document.prototype.contains
- Range.prototype.intersectsNode
### Fixes for IE/Edge compatibility:
- `Selection.prototype.selectMarkers` (converts `<em class="scribe-marker">` elements used as selection markers into actual selection). This is reworked to be IE/Edge compatible.
- With IE contenteditable elements do not trigger `input` events that capture user input and changes triggered by `document.execCommand`. This has been reworked to be compatible with IE by using other events + wrapping around the `document.execCommand` method.
- Added a helper function `createCustomEvent` so that custom DOM events can be created in a IE compatible way.
