### PR TITLE
Fix the wrapping of document.execCOmmand

### DIFF
--- a/src/scribe.js
+++ b/src/scribe.js
@@ -45,8 +45,9 @@ define([
     var origExecCommand = document.execCommand;
 
     document.execCommand = function() {
-      origExecCommand.apply(document, arguments);
+      var result = origExecCommand.apply(document, arguments);
       this.transactionManager.run();
+      return result;
     }.bind(this);
 
     var transactionRun = function() {


### PR DESCRIPTION
@kencheeto 

This PR fixes the wrapping of the `document.execCommand` by properly returning the original result of the execution.
