### PR TITLE
[AI-4486] Fix for adding of extra empty lines on content insertion

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -101,7 +101,6 @@ define([
   }
 
   function wrap(nodes, parentNode) {
-    nodes[0].parentNode.insertBefore(parentNode, nodes[0]);
     nodes.forEach(function (node) {
       parentNode.appendChild(node);
     });


### PR DESCRIPTION
@vcekov 
https://zendesk.atlassian.net/browse/AI-4486

This removes a line from the internal "wrap" function which scribe uses to attempt to ensure that new content stays inside the parent node. Unfortunately, instead, this was simply creating consistent bugs upon insertion of content wherein items got pulled out of the parent node, ultimately leaving extra p-tags at the beginning of new content.

Along with the associated lotus PR https://github.com/zendesk/zendesk_console/pull/10713, this fixes a bug where extra lines get added onto macro-based comment content.
