### PR TITLE
Change the way formatters are applied for IE

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -101,6 +101,7 @@ define([
   }
 
   function wrap(nodes, parentNode) {
+    nodes[0].parentNode.insertBefore(parentNode, nodes[0]);
     nodes.forEach(function (node) {
       parentNode.appendChild(node);
     });

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -79,6 +79,8 @@ define([
       // For IE we rely on hitting Enter to run the formatters as the mutation observer
       // causes trouble when integrating into an Ember app.
       if (/Trident/.test(navigator.userAgent)) {
+        // do initial formatting
+        scribe._applyFormatters();
         scribe.el.addEventListener('keydown', function(e) {
           if (e.which === 13) { // key "Enter"
             scribe._applyFormatters();

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -46,7 +46,7 @@ define([
       /**
        * Apply the formatters when there is a DOM mutation.
        */
-      var applyFormatters = function() {
+      scribe._applyFormatters = function() {
         if (!scribe._skipFormatters) {
           var selection = new scribe.api.Selection();
           var isEditorActive = selection.range;
@@ -55,7 +55,7 @@ define([
             if (isEditorActive) {
               selection.placeMarkers();
             }
-            scribe.setHTML(scribe._htmlFormatterFactory.format(scribe.getHTML()));
+            scribe.setRawHTML(scribe._htmlFormatterFactory.format(scribe.getHTML()));
             selection.selectMarkers();
           };
 
@@ -81,11 +81,14 @@ define([
       if (/Trident/.test(navigator.userAgent)) {
         scribe.el.addEventListener('keydown', function(e) {
           if (e.which === 13) { // key "Enter"
-            applyFormatters();
+            scribe._applyFormatters();
           }
         }, false);
+        scribe.on('paste', function(e) {
+          scribe._applyFormatters();
+        }, false);
       } else {
-        observeDomChanges(scribe.el, applyFormatters);
+        observeDomChanges(scribe.el, scribe._applyFormatters);
       }
 
       // TODO: disconnect on tear down:

--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -41,7 +41,7 @@ define([
             selection.selection.addRange(range);
           }
         }
-      }.bind(scribe));
+      });
 
       /**
        * Apply the formatters when there is a DOM mutation.
@@ -57,7 +57,7 @@ define([
             }
             scribe.setHTML(scribe._htmlFormatterFactory.format(scribe.getHTML()));
             selection.selectMarkers();
-          }.bind(scribe);
+          };
 
           // We only want to wrap the formatting in a transaction if the editor is
           // active. If the DOM is mutated when the editor isn't active (e.g.
@@ -74,9 +74,19 @@ define([
         }
 
         delete scribe._skipFormatters;
-      }.bind(scribe);
+      };
 
-      observeDomChanges(scribe.el, applyFormatters);
+      // For IE we rely on hitting Enter to run the formatters as the mutation observer
+      // causes trouble when integrating into an Ember app.
+      if (/Trident/.test(navigator.userAgent)) {
+        scribe.el.addEventListener('keydown', function(e) {
+          if (e.which === 13) { // key "Enter"
+            applyFormatters();
+          }
+        }, false);
+      } else {
+        observeDomChanges(scribe.el, applyFormatters);
+      }
 
       // TODO: disconnect on tear down:
       // observer.disconnect();

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -169,11 +169,15 @@ define([
   };
 
   Scribe.prototype.setHTML = function (html, skipFormatters) {
+    this.setRawHTML(html);
+    if (!skipFormatters) {
+      this._applyFormatters && this._applyFormatters(html);
+    }
+  };
+
+  Scribe.prototype.setRawHTML = function (html) {
     this._lastItem.content = html;
 
-    if (skipFormatters) {
-      this._skipFormatters = true;
-    }
     // IE11: Setting HTML to the value it already has causes breakages elsewhere (see #336)
     if (this.el.innerHTML !== html) {
       this.el.innerHTML = html;

--- a/src/scribe.js
+++ b/src/scribe.js
@@ -169,8 +169,13 @@ define([
   };
 
   Scribe.prototype.setHTML = function (html, skipFormatters) {
+    if (skipFormatters) {
+      this._skipFormatters = true;
+    }
+
     this.setRawHTML(html);
-    if (!skipFormatters) {
+
+    if (/Trident/.test(navigator.userAgent) && !skipFormatters) {
       this._applyFormatters && this._applyFormatters(html);
     }
   };


### PR DESCRIPTION
@kencheeto @roseleaf 

This fixes issues with IE11. This change will start applying text formatters on "Enter" and not on every change of the scribe editor's DOM. This solves the JS errors and incompatibility of IE11 + scribe + Ember.
