### PR TITLE
Fix IE issues

### DIFF
--- a/src/plugins/core/events.js
+++ b/src/plugins/core/events.js
@@ -83,7 +83,9 @@ define([
         scribe._applyFormatters();
         scribe.el.addEventListener('keydown', function(e) {
           if (e.which === 13) { // key "Enter"
-            scribe._applyFormatters();
+            setTimeout(function() {
+              scribe._applyFormatters();
+            }, 10);
           }
         }, false);
         scribe.on('paste', function(e) {

--- a/src/plugins/core/patches/events.js
+++ b/src/plugins/core/patches/events.js
@@ -11,8 +11,9 @@ define([], function () {
       // TODO: share somehow with `InsertList` command
 
       var nodeHelpers = scribe.node;
+      var isIE = /Trident/.test(window.navigator.userAgent);
 
-      if (scribe.allowsBlockElements()) {
+      if (isIE && scribe.allowsBlockElements()) {
         scribe.el.addEventListener('keyup', function (event) {
           if (event.keyCode === 8 || event.keyCode === 46) { // backspace or delete
 


### PR DESCRIPTION
This fixes the following issues with IE:
- Pressing "enter" in the middle of a paragraph does not move the rest of the paragraph content into a new paragraph
- Pressing "backspace" moves the cursor to the beginning of the line  
