### PR TITLE
Set empty state for IE

### DIFF
--- a/src/scribe.js
+++ b/src/scribe.js
@@ -36,13 +36,13 @@ function configureZeroState(scribe) {
   // make sure there is always at least one paragraph
   if (!scribe.el.firstElementChild) {
     if (scribe.el.firstChild && scribe.el.firstChild.nodeType === Node.TEXT_NODE) {
-      scribe.el.innerHTML = '<p>' + scribe.el.firstChild.textContent + '</p>';
+      scribe.el.innerHTML = '<p>' + scribe.el.firstChild.textContent + '<br></p>';
     } else {
       scribe.el.innerHTML = '<p><br></p>';
     }
     var sel = window.getSelection();
     var range = document.createRange();
-    range.selectNode(scribe.el.querySelector('br'));
+    range.selectNode(scribe.el.querySelector('p').firstChild);
     range.collapse(true);
     sel.removeAllRanges();
     sel.addRange(range);


### PR DESCRIPTION
This PR fixes an issue where selecting all text and deleting it and typing produces a js error.
