### PR TITLE
Remove markers that break comp events for IME

### DIFF
--- a/src/plugins/core/patches/events.js
+++ b/src/plugins/core/patches/events.js
@@ -39,9 +39,7 @@ define([], function () {
 
               scribe.transactionManager.run(function () {
                 // Store the caret position
-                selection.placeMarkers();
                 nodeHelpers.removeChromeArtifacts(containerPElement);
-                selection.selectMarkers();
               }, true);
             }
           }


### PR DESCRIPTION
After `compositionstart` is fired, DOM mutations will stop composition. This will result in whole words of Chinese/Korean/Japanese/ being deleted when the `delete` key is pressed.

There are `em` tags inserted into the scribe editor when selection changes. This is done to help serialize the editor state w/ selection. And that serialization is used to keep track of state for undo/redo.

@vcekov wrote his own history manager with node attributes for selection serialization, so this change should not break anything.

We no longer need these markers, and removing all references to them in the core fork is work for the technical bucket.

This 🐛 sucked

![selfie-0](http://i.imgur.com/0kNTVu2.png)
[_GitHub Selfies_](https://github.com/thieman/github-selfies/)
