### PR TITLE
Fix empty paragraph parsing for IE

### DIFF
--- a/src/plugins/core/formatters/html/enforce-p-elements.js
+++ b/src/plugins/core/formatters/html/enforce-p-elements.js
@@ -78,8 +78,10 @@ define([
          * which is something undesired.
          */
 
-        [].forEach.call(bin.querySelectorAll('p:empty'), function(p) {
-          p.parentNode.removeChild(p);
+        [].forEach.call(bin.querySelectorAll('p'), function(p) {
+          if (!p.firstChild) {
+            p.parentNode.removeChild(p);  
+          }
         });
 
         wrapChildNodes(bin);


### PR DESCRIPTION
@roseleaf 

It turns out running `div.querySelectorAll("p:empty")` in IE produces a javascript error. This PR fixes this issue.
